### PR TITLE
hotfixes: correção da conexão com o banco de dados

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+SQL_ENGINE=django.db.backends.postgresql
+SQL_DATABASE=bookstore_dev_db
+SQL_USER=bookstore_dev
+SQL_PASSWORD=E3I1NmSjMsIUW9gA
+SQL_HOST=localhost
+SQL_PORT=5432

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ celerybeat.pid
 
 # Environments
 .env
+!.env.sample
 .venv
 env/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ RUN poetry install --no-dev
 # Expose port 8000 for the app
 EXPOSE 8000
 
-CMD ["gunicorn", "bookstore.wsgi:application", "--bind", "0.0.0.0:8000"]
-
+ENTRYPOINT [ "scripts/start.sh" ]
+CMD [ "" ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2024-present Lenon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+# Bookstore
 
 Bem-vindo à API da Bookstore! Esta API foi desenvolvida usando Django e Django REST Framework e fornece funcionalidades para gerenciar produtos e pedidos de uma livraria.
 
@@ -16,14 +16,19 @@ Bem-vindo à API da Bookstore! Esta API foi desenvolvida usando Django e Django 
 
 1. Clone o repositório:
 
-   ```sh
-   git clone https://github.com/seu-usuario/bookstore.git
-   cd bookstore
+```sh
+git clone https://github.com/seu-usuario/bookstore.git
+cd bookstore
+```
+
 Instale as dependências do projeto usando Poetry:
 
-sh
+```sh
 poetry install
-Configuração
+```
+
+## Configuração
+
 Crie um arquivo .env ou env.dev no diretório raiz do projeto com as seguintes variáveis:
 
 plaintext
@@ -36,22 +41,31 @@ SQL_USER=bookstore_dev
 SQL_PASSWORD=bookstore_dev
 SQL_HOST=db
 SQL_PORT=5432
+
 Configure o Docker Compose para iniciar os serviços necessários:
 
-sh
+```sh
 docker-compose up --build
-Executando o Projeto
+```
+
+## Executando o Projeto
+
 Inicie os serviços Docker:
 
-sh
+```sh
 docker-compose up -d
+```
+
 Acesse a aplicação no navegador:
 
 http://localhost:8000
-Endpoints
+
+
+## Endpoints
+
 A API possui os seguintes endpoints principais:
 
-Produtos
+### Produtos
 
 GET /bookstore/v1/product/ - Lista todos os produtos
 
@@ -63,7 +77,7 @@ PUT /bookstore/v1/product/:id/ - Atualiza um produto pelo ID
 
 DELETE /bookstore/v1/product/:id/ - Deleta um produto pelo ID
 
-Pedidos
+### Pedidos
 
 GET /bookstore/v1/order/ - Lista todos os pedidos
 
@@ -75,12 +89,16 @@ PUT /bookstore/v1/order/:id/ - Atualiza um pedido pelo ID
 
 DELETE /bookstore/v1/order/:id/ - Deleta um pedido pelo ID
 
-Testes
+## Testes
+
 Execute os testes do projeto usando o comando:
 
-sh
+```sh
 docker-compose exec web python manage.py test
-Contribuição
+```
+
+## Contribuição
+
 Se você deseja contribuir com este projeto, por favor siga os passos abaixo:
 
 Faça um fork do repositório
@@ -93,8 +111,6 @@ Faça um push para a branch (git push origin feature/nova-feature)
 
 Abra um Pull Request
 
-Licença
+## Licença
+
 Este projeto está licenciado sob a licença MIT. Veja o arquivo LICENSE para mais detalhes.
-
-
-

--- a/bookstore/settings.py
+++ b/bookstore/settings.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import os
 from decouple import config
-import dj_database_url
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -60,12 +59,12 @@ WSGI_APPLICATION = "bookstore.wsgi.application"
 
 DATABASES = {
     'default': {
-        'ENGINE': config('SQL_ENGINE', default='django.db.backends.mysql'),
-        'NAME': config('SQL_DATABASE', default='bookstore_db'),
-        'USER': config('SQL_USER', default='root'),
+        'ENGINE': config('SQL_ENGINE', default='django.db.backends.postgresql'),
+        'NAME': config('SQL_DATABASE', default='bookstore_dev_db'),
+        'USER': config('SQL_USER', default='bookstore_dev'),
         'PASSWORD': config('SQL_PASSWORD'),
         'HOST': config('SQL_HOST', default='localhost'),
-        'PORT': config('SQL_PORT', default=3306, cast=int),
+        'PORT': config('SQL_PORT', default=5432, cast=int),
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ version: "3.9"
 services:
   db:
     image: postgres:13.0-alpine
+    hostname: postgres-instance
     ports:
       - 5432:5432
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
       - POSTGRES_USER=bookstore_dev
-      - POSTGRES_PASSWORD=bookstore_dev
+      - POSTGRES_PASSWORD=E3I1NmSjMsIUW9gA
       - POSTGRES_DB=bookstore_dev_db
 
   web:
@@ -19,8 +20,15 @@ services:
       - app_data:/usr/src/app/
     ports:
       - 8000:8000
-    env_file:
-      - .env
+    environment:
+      - DEBUG=True
+      - DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+      - SQL_ENGINE=django.db.backends.postgresql
+      - SQL_DATABASE=bookstore_dev_db
+      - SQL_USER=bookstore_dev
+      - SQL_PASSWORD=E3I1NmSjMsIUW9gA
+      - SQL_HOST=postgres-instance
+      - SQL_PORT=5432
     depends_on:
       - db
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+python manage.py makemigrations
+gunicorn bookstore.wsgi:application --bind "0.0.0.0:8000"


### PR DESCRIPTION
Modificações

- Corrigi a conexão com o banco de dados: existia algumas definições de conexão para banco de dados MySQL, enquanto estava sendo configurando o PostgreSQL no Docker. Eu alterei as configurações para usar o Postgres no back-end, removendo as configurações baseadas no MySQL;
- Criei um script em `scripts/start.sh`, que é executado quando o container Docker da aplicação está sendo executado. Coloquei duas execuções no script: uma para rodar as migrations do Django, outro para executar a aplicação. Ainda que as migrations tenham sido executadas, parece que a aplicação no Django não está bem configurada ainda, já que quando eu entro no endpoint de listagem de produtos, aparece erro informando que a relação `product_product` não existe. Acho que compensa dar uma olhada nessas questões;
- Criei um `.env.sample` como um template de como criar as variáveis e os valores do arquivo `.env` para o ambiente de desenvolvimento. Em geral, quando vamos colocar em produção, por exemplo, criamos novos valores para as variáveis (como nome de usuário, senha e nome do banco de dados). Coloquei os mesmos valores no docker-compose; e
- Adicionei o arquivo de LICENSE.